### PR TITLE
🔀 :: (#40) - ability to change quantity in shopping cart

### DIFF
--- a/app/src/main/java/com/g3c1/oasis_android/di/module/NetworkModule.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/di/module/NetworkModule.kt
@@ -37,7 +37,7 @@ object NetworkModule {
         gsonConverterFactory: GsonConverterFactory
     ): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(FakeUrl.BASE_URL)
+            .baseUrl(BaseUrl.BASE_URL)
             .client(okHttpClient)
             .client(provideOkhttpClient())
             .addConverterFactory(gsonConverterFactory)

--- a/app/src/main/java/com/g3c1/oasis_android/di/module/NetworkModule.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/di/module/NetworkModule.kt
@@ -37,7 +37,7 @@ object NetworkModule {
         gsonConverterFactory: GsonConverterFactory
     ): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(BaseUrl.BASE_URL)
+            .baseUrl(FakeUrl.BASE_URL)
             .client(okHttpClient)
             .client(provideOkhttpClient())
             .addConverterFactory(gsonConverterFactory)

--- a/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/shopping_basket/BottomSheet.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/shopping_basket/BottomSheet.kt
@@ -2,16 +2,13 @@ package com.g3c1.oasis_android.feature_menu.presentation.shopping_basket
 
 import android.util.Log
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -38,7 +35,7 @@ fun BottomSheet(viewModel: MenuViewModel) {
         scaffoldState = bottomSheetScaffoldState,
         sheetShape = RoundedCornerShape(topEnd = 30.dp, topStart = 30.dp),
         sheetContent = {
-            val orderMenuList = remember{ viewModel.orderMenuList }
+            val orderMenuList = remember { viewModel.orderMenuList }
             Log.d("TAG", "BottomSheet: orderMenuList = $orderMenuList")
             Column(
                 modifier = Modifier.fillMaxSize(),
@@ -65,7 +62,10 @@ fun BottomSheet(viewModel: MenuViewModel) {
                         .height(72.dp),
                 ) {
                     items(orderMenuList.size) {
-                        OrderedMenuComponent(data = orderMenuList[it])
+                        OrderedMenuComponent(
+                            data = orderMenuList[it],
+                            viewModel = viewModel
+                        )
                     }
                 }
             }
@@ -90,4 +90,5 @@ fun BottomSheet(viewModel: MenuViewModel) {
             MenuNavigation(viewModel = viewModel, menuDataList = list)
         }
     }
+
 }

--- a/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/shopping_basket/component/OrderedMenuComponent.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/shopping_basket/component/OrderedMenuComponent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -12,18 +13,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberImagePainter
 import com.g3c1.oasis_android.feature_menu.data.dto.OrderFoodDTO
+import com.g3c1.oasis_android.feature_menu.presentation.vm.MenuViewModel
 import com.g3c1.oasis_android.ui.theme.Font
-import com.g3c1.oasis_android.ui.theme.Gray4
 import com.g3c1.oasis_android.ui.theme.Gray5
 
 @OptIn(ExperimentalCoilApi::class)
 @Composable
-fun OrderedMenuComponent(data: OrderFoodDTO) {
+fun OrderedMenuComponent(
+    data: OrderFoodDTO,
+    viewModel: MenuViewModel
+) {
     Column {
         Row(
             modifier = Modifier
@@ -65,15 +70,24 @@ fun OrderedMenuComponent(data: OrderFoodDTO) {
                     modifier = Modifier
                         .clip(RoundedCornerShape(20.dp))
                         .background(Gray5)
-                        .padding(10.dp, 0.dp, 10.dp, 0.dp),
+                        .padding(10.dp, 0.dp, 10.dp, 0.dp)
+                        .width(80.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.End
                 ) {
-                    Text(text = "-", fontSize = 23.sp)
-                    Spacer(modifier = Modifier.width(11.dp))
+                    IconButton(
+                        onClick = { viewModel.decreaseFoodAmount(data.id) },
+                        modifier = Modifier.size(28.dp)
+                    ) {
+                        Text(text = "-", fontSize = 23.sp, textAlign = TextAlign.Center)
+                    }
                     Text(text = "${data.amount}개", fontSize = 13.sp)
-                    Spacer(modifier = Modifier.width(11.dp))
-                    Text(text = "+", fontSize = 16.sp)
+                    IconButton(
+                        onClick = { viewModel.increaseOnlyOneAmount(data.id) },
+                        modifier = Modifier.size(28.dp)
+                    ) {
+                        Text(text = "+", fontSize = 16.sp, textAlign = TextAlign.Center)
+                    }
                 }
                 Spacer(modifier = Modifier.width(31.dp))
                 Text(text = "삭제", fontSize = 14.sp, fontFamily = Font.pretendard)

--- a/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/shopping_basket/component/OrderedMenuComponent.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/shopping_basket/component/OrderedMenuComponent.kt
@@ -79,14 +79,24 @@ fun OrderedMenuComponent(
                         onClick = { viewModel.decreaseFoodAmount(data.id) },
                         modifier = Modifier.size(28.dp)
                     ) {
-                        Text(text = "-", fontSize = 23.sp, textAlign = TextAlign.Center)
+                        Text(
+                            text = "-",
+                            fontSize = 18.sp,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxSize()
+                        )
                     }
                     Text(text = "${data.amount}개", fontSize = 13.sp)
                     IconButton(
                         onClick = { viewModel.increaseOnlyOneAmount(data.id) },
                         modifier = Modifier.size(28.dp)
                     ) {
-                        Text(text = "+", fontSize = 16.sp, textAlign = TextAlign.Center)
+                        Text(
+                            text = "+",
+                            fontSize = 18.sp,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxSize()
+                        )
                     }
                 }
                 Spacer(modifier = Modifier.width(31.dp))

--- a/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/vm/MenuViewModel.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/vm/MenuViewModel.kt
@@ -81,12 +81,14 @@ class MenuViewModel @Inject constructor(
         Log.d("TAG", "orderMenuList: $_orderMenuList")
     }
 
-    fun decreaseFoodAmount(itemId: Int, count: Int) {
+    fun decreaseFoodAmount(itemId: Int) {
         val (id, name, img, price, amount) = _orderMenuList[getFoodPosition(itemId = itemId)]
-        _orderMenuList[getFoodPosition(itemId = itemId)] =
-            OrderFoodDTO(id = id, name = name, img = img, price = price, amount = amount - count)
+        if(amount > 1) {
+            _orderMenuList[getFoodPosition(itemId = itemId)] =
+                OrderFoodDTO(id = id, name = name, img = img, price = price, amount = amount - 1)
 
-        Log.d("TAG", "orderMenuList: $_orderMenuList")
+            Log.d("TAG", "orderMenuList: $_orderMenuList")
+        }
     }
 
     private fun addFoodToTheFoodToOrderList(itemId: Int, amount: Int) {
@@ -108,4 +110,11 @@ class MenuViewModel @Inject constructor(
         _menuList.clear()
         data.forEach { _menuList.add(it) }
     }
+
+    fun increaseOnlyOneAmount(itemId: Int) {
+        val (id, name, img, price, amount) = _orderMenuList[getFoodPosition(itemId = itemId)]
+        _orderMenuList[getFoodPosition(itemId = itemId)] =
+            OrderFoodDTO(id = id, name = name, img = img, price = price, amount = amount + 1)
+    }
+
 }


### PR DESCRIPTION
## 개요
*  장바구니에서 음식의 수량을 변경할 수 있도록 합니다.

## 작업 내용
![image](https://user-images.githubusercontent.com/82383983/201069812-06c1b094-15a2-43d1-97d1-86a37d41f31f.png)
![image](https://user-images.githubusercontent.com/82383983/201069848-06398ea4-5ce8-43df-9f16-40872c3169d8.png)

## 주요 코드
* 버튼 클릭 로직 추가
https://github.com/G3C1/Oasis-Android/blob/b47ad0200bc6516bbc1da8a7b50522d188087eae/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/shopping_basket/component/OrderedMenuComponent.kt#L78-L100

* 값 증가
https://github.com/G3C1/Oasis-Android/blob/b47ad0200bc6516bbc1da8a7b50522d188087eae/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/vm/MenuViewModel.kt#L114-L118

* 값 감소
https://github.com/G3C1/Oasis-Android/blob/b47ad0200bc6516bbc1da8a7b50522d188087eae/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/vm/MenuViewModel.kt#L84-L92