### PR TITLE
🔀 :: (#83) - 디테일 페이지 가격 텍스트 밀리는 이슈 해결

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="Android Studio default JDK" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/src/main/java/com/g3c1/oasis_android/di/module/NetworkModule.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/di/module/NetworkModule.kt
@@ -39,7 +39,7 @@ object NetworkModule {
         gsonConverterFactory: GsonConverterFactory
     ): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(BaseUrl.BASE_URL)
+            .baseUrl(FakeUrl.BASE_URL)
             .client(okHttpClient)
             .client(provideOkhttpClient())
             .addConverterFactory(gsonConverterFactory)

--- a/app/src/main/java/com/g3c1/oasis_android/di/module/NetworkModule.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/di/module/NetworkModule.kt
@@ -39,7 +39,7 @@ object NetworkModule {
         gsonConverterFactory: GsonConverterFactory
     ): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(FakeUrl.BASE_URL)
+            .baseUrl(BaseUrl.BASE_URL)
             .client(okHttpClient)
             .client(provideOkhttpClient())
             .addConverterFactory(gsonConverterFactory)

--- a/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/detail/FoodDetailScreen.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/detail/FoodDetailScreen.kt
@@ -91,6 +91,7 @@ fun FoodDetailScreen(
                     text = "${data.servings}인분",
                     fontFamily = Font.pretendard,
                     fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
                     modifier = Modifier.align(
                         Alignment.CenterStart
                     )
@@ -99,6 +100,7 @@ fun FoodDetailScreen(
                     text = "${data.price}원",
                     fontFamily = Font.pretendard,
                     fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
                     modifier = Modifier.align(
                         Alignment.CenterEnd
                     )

--- a/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/detail/FoodDetailScreen.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/detail/FoodDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.g3c1.oasis_android.feature_menu.presentation.detail
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.IconButton
@@ -26,6 +27,7 @@ import com.g3c1.oasis_android.feature_menu.data.dto.MenuDTO
 import com.g3c1.oasis_android.feature_menu.presentation.shopping_basket.component.ShoppingBasketButton
 import com.g3c1.oasis_android.feature_menu.presentation.vm.MenuViewModel
 import com.g3c1.oasis_android.ui.theme.Font
+import com.g3c1.oasis_android.ui.theme.LightGray
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoilApi::class)
@@ -106,6 +108,12 @@ fun FoodDetailScreen(
                     )
                 )
             }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(2.dp)
+                    .background(LightGray)
+            )
             Row(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/detail/FoodDetailScreen.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/feature_menu/presentation/detail/FoodDetailScreen.kt
@@ -37,7 +37,7 @@ fun FoodDetailScreen(
     menuList: List<MenuDTO>
 ) {
 
-    val count = remember { mutableStateOf(1)}
+    val count = remember { mutableStateOf(1) }
     val allMenuList = mutableListOf<FoodDTO>()
     val scope = rememberCoroutineScope()
 
@@ -82,20 +82,35 @@ fun FoodDetailScreen(
                 fontWeight = FontWeight.Normal,
                 fontSize = 14.sp
             )
-            Row(modifier = Modifier
-                .fillMaxWidth()
-                .height(60.dp),
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(60.dp)
+            ) {
+                Text(
+                    text = "${data.servings}인분",
+                    fontFamily = Font.pretendard,
+                    fontSize = 16.sp,
+                    modifier = Modifier.align(
+                        Alignment.CenterStart
+                    )
+                )
+                Text(
+                    text = "${data.price}원",
+                    fontFamily = Font.pretendard,
+                    fontSize = 16.sp,
+                    modifier = Modifier.align(
+                        Alignment.CenterEnd
+                    )
+                )
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(60.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(text = "${data.servings}인분", fontFamily = Font.pretendard, fontSize = 16.sp)
-                Spacer(modifier = Modifier.width(290.dp))
-                Text(text = "${data.price}원", fontFamily = Font.pretendard, fontSize = 16.sp)
-            }
-            Row(modifier = Modifier
-                .fillMaxWidth()
-                .height(60.dp),
-            verticalAlignment = Alignment.CenterVertically) {
-                IconButton(onClick = { if(count.value > 1) count.value = count.value - 1}) {
+                IconButton(onClick = { if (count.value > 1) count.value = count.value - 1 }) {
                     Text(text = "-")
                 }
                 Text(text = count.value.toString(), textAlign = TextAlign.Center)
@@ -110,14 +125,15 @@ fun FoodDetailScreen(
             verticalArrangement = Arrangement.Bottom,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            ShoppingBasketButton (onClick = {
-                scope.launch {
-                    viewModel.checkIfFoodIsOnTheList(itemId = menuId!!, amount = count.value)
-                    navController.popBackStack()
-                }
-            },
-            visibility = true,
-            count.value * data.price
+            ShoppingBasketButton(
+                onClick = {
+                    scope.launch {
+                        viewModel.checkIfFoodIsOnTheList(itemId = menuId!!, amount = count.value)
+                        navController.popBackStack()
+                    }
+                },
+                visibility = true,
+                count.value * data.price
             )
         }
     }

--- a/app/src/main/java/com/g3c1/oasis_android/ui/theme/Font.kt
+++ b/app/src/main/java/com/g3c1/oasis_android/ui/theme/Font.kt
@@ -17,5 +17,5 @@ object Font {
         Font(R.font.pretendard_regular, FontWeight.Normal, FontStyle.Normal),
         Font(R.font.pretendard_semi_bold, FontWeight.SemiBold, FontStyle.Normal),
         Font(R.font.pretendard_thin, FontWeight.Thin, FontStyle.Normal),
-        )
+    )
 }


### PR DESCRIPTION
## 개요
*  디테일 페이지 가격 텍스트 밀리는 이슈 해결

## 작업 내용
* Spacer로 dp만큼 떨어뜨리는게 아닌 각각 align을 다르게 줘서 텍스트가 밀리지 않도록 하였습니다.
* 폰트를 디자인에 맞게 수정했습니다.
* 디자인에 맞게 하단에 회색 바를 추가하였습니다.

## 작업 결과
![image](https://user-images.githubusercontent.com/80810303/235430899-615ed075-5012-4048-a9e3-95a14dfbcd12.png)
